### PR TITLE
feat(recommendations): add endpoint and logic for fresh recommendations

### DIFF
--- a/app/crud/recommendation.py
+++ b/app/crud/recommendation.py
@@ -1,0 +1,47 @@
+# Standard library imports
+import datetime
+
+# Third-party imports
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
+from sqlalchemy import literal
+
+# Local imports
+from app import models
+from app.schemas.recommendation import Recommendation
+
+
+def get_recommendations(db: Session, limit: int = 10) -> list[Recommendation]:
+    date_range = datetime.datetime.utcnow() - datetime.timedelta(days=30)
+
+    last_reviews_subquery = (
+        db.query(
+            models.ReviewModel.location_id,
+            models.ReviewModel.category_id,
+            func.max(models.ReviewModel.reviewed_at).label('last_reviewed_at')
+        )
+        .group_by(
+            models.ReviewModel.location_id,
+            models.ReviewModel.category_id
+        )
+        .subquery()
+    )
+
+    recommendations_query = (db.query(
+        models.LocationModel.id.label('location_id'),
+        models.CategoryModel.id.label('category_id'),
+        (last_reviews_subquery.c.last_reviewed_at.is_(None)).label('never_reviewed')
+    ).select_from(models.LocationModel).join(models.CategoryModel, literal(True)).outerjoin(
+        last_reviews_subquery,
+        (models.LocationModel.id == last_reviews_subquery.c.location_id) &
+        (models.CategoryModel.id == last_reviews_subquery.c.category_id)
+    ).filter(
+        (last_reviews_subquery.c.last_reviewed_at.is_(None)) |
+        (last_reviews_subquery.c.last_reviewed_at < date_range)
+    ).order_by(
+        (last_reviews_subquery.c.last_reviewed_at.is_(None)).desc(),
+        last_reviews_subquery.c.last_reviewed_at.asc()
+    ).limit(limit))
+
+    results = recommendations_query.all()
+    return [Recommendation(**recommendation._mapping) for recommendation in results]

--- a/app/routers/recommendations.py
+++ b/app/routers/recommendations.py
@@ -1,0 +1,23 @@
+# Third-party imports
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+# Local imports
+from app import crud
+from app.dependencies.session import get_db
+from app.schemas.recommendation import Recommendation
+
+
+router = APIRouter(prefix="/recommendations", tags=["Recommendations"])
+
+
+@router.get(
+    path="/",
+    response_model=list[Recommendation]
+)
+def get_recommendations(limit:int = 10, db: Session = Depends(get_db)):
+    """
+    Returns up to 10 location-category combos not reviewed in last 30 days,
+    prioritizing combos never reviewed.
+    """
+    return crud.get_recommendations(db, limit=limit)

--- a/app/schemas/recommendation.py
+++ b/app/schemas/recommendation.py
@@ -1,0 +1,8 @@
+# Third-party imports
+from pydantic import BaseModel
+
+
+class Recommendation(BaseModel):
+    location_id: int
+    category_id: int
+    never_reviewed: bool


### PR DESCRIPTION
Introduced recommendation feature to surface location–category pairs that need new reviews:

    Defined /recommendations/ GET route with optional limit parameter.

    Created get_recommendations CRUD function using a subquery to compute the most recent review per pair.

    Filtered out combos reviewed within the last 30 days and prioritized never-reviewed pairs.

    Mapped query results into Recommendation schema with never_reviewed flag.