### PR TITLE
test(category): add pytest coverage for category endpoints

### DIFF
--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,37 @@
+# Third-party imports
+import pytest
+from fastapi import status
+
+# Local imports
+from tests.fixtures.database import client
+
+
+@pytest.fixture()
+def payload_category(fake):
+    return {"name": fake.word()}
+
+
+@pytest.mark.usefixtures("client", "payload_category")
+class TestCategories:
+
+    def test_create_category(self, client, payload_category):
+        response = client.post("/categories/", json=payload_category)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["name"] == payload_category.get("name")
+
+    def test_list_categories(self, client, payload_category):
+        client.post("/categories/", json=payload_category)
+        response = client.get("/categories/")
+
+        assert response.status_code == status.HTTP_200_OK
+        categories = response.json()
+        assert any(category["name"] == payload_category.get("name") for category in categories)
+
+    def test_create_category_conflict(self, client, payload_category):
+        response = client.post("/categories/", json=payload_category)
+        assert response.status_code == status.HTTP_201_CREATED
+
+        response = client.post("/categories/", json=payload_category)
+        assert response.status_code == status.HTTP_409_CONFLICT

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,7 +1,5 @@
 # Third-party imports
 from fastapi import status
-
-# Third-party imports
 import pytest
 
 # Local imports
@@ -35,11 +33,13 @@ class TestLocations:
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert any(
-            location["latitude"] == pytest.approx(payload_location["latitude"]) and
-            location["longitude"] == pytest.approx(payload_location["longitude"])
+            location["latitude"] == pytest.approx(payload_location.get("latitude")) and
+            location["longitude"] == pytest.approx(payload_location.get("longitude"))
             for location in data
         )
     def test_create_location_conflict(self, client, payload_location):
-        client.post("/locations/", json=payload_location)
+        response = client.post("/locations/", json=payload_location)
+        assert response.status_code == status.HTTP_201_CREATED
+
         response = client.post("/locations/", json=payload_location)
         assert response.status_code ==  status.HTTP_409_CONFLICT


### PR DESCRIPTION
Added tests to verify the Categories API behavior:

    test_create_category ensures a category can be created and returns the correct name.

    test_list_categories confirms the list endpoint includes the newly created category.

    test_create_category_conflict checks that creating a duplicate category returns a 409 Conflict.