### PR TITLE
eat(docker): add Dockerfile and Docker usage instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ The API will be available at `http://127.0.0.1:8000`.
 
 ---
 
+## Docker
+
+Build and run the API in a container:
+
+1. Build the image:
+   ```bash
+   docker build -t map-my-world-api .
+   ```
+2. Run the container:
+   ```bash
+   docker run -p 8000:8000 map-my-world-api
+   ```
+The API is available at `http://localhost:8000`.
+
+---
+
 ## Endpoints
 
 ### Locations


### PR DESCRIPTION
Included containerization support for the Map My World API:

    Added Dockerfile based on python:3.11-slim to build and run the application in a container.

    Updated README.md with Docker build and run steps to expose port 8000 and make the API available at http://localhost:8000.