### PR TITLE
refactor(tests-fixtures): replace raw SQL inserts with ORM model usage

### DIFF
--- a/tests/fixtures/categories.py
+++ b/tests/fixtures/categories.py
@@ -2,6 +2,8 @@
 import pytest
 from sqlalchemy import text
 
+from app.models import CategoryModel
+
 
 @pytest.fixture()
 def payload_category(fake):
@@ -20,16 +22,12 @@ def payload_categories(fake):
 
 @pytest.fixture()
 def setup_categories(db_session, fake, payload_categories):
-    categories = payload_categories(3)
-    inserted_ids = []
+    payload_categories = payload_categories(3)
 
-    for category in categories:
-        db_session.execute(
-            text("INSERT INTO categories (name) VALUES (:name)"),
-            category
-        )
-        row = db_session.execute(text("SELECT last_insert_rowid()")).scalar_one()
-        inserted_ids.append(row)
+    categories = [CategoryModel(**data) for data in payload_categories]
+    db_session.add_all(categories)
+    db_session.flush()
+    category_ids = [category.id for category in categories]
 
     db_session.commit()
-    return inserted_ids
+    return category_ids

--- a/tests/fixtures/locations.py
+++ b/tests/fixtures/locations.py
@@ -1,6 +1,8 @@
 # Third-party imports
 import pytest
-from sqlalchemy import text
+
+# Local imports
+from app.models.location import LocationModel
 
 
 @pytest.fixture()
@@ -26,16 +28,12 @@ def payload_locations(fake):
 
 @pytest.fixture()
 def setup_locations(db_session, payload_locations):
-    locations = payload_locations(3)
-    inserted_ids = []
+    payload_locations = payload_locations(3)
 
-    for location in locations:
-        db_session.execute(
-            text("INSERT INTO locations (latitude, longitude) VALUES (:latitude, :longitude)"),
-            location
-        )
-        row = db_session.execute(text("SELECT last_insert_rowid()")).scalar_one()
-        inserted_ids.append(row)
+    locations = [LocationModel(**data) for data in payload_locations]
+    db_session.add_all(locations)
+    db_session.flush()
+    location_ids = [location.id for location in locations]
 
     db_session.commit()
-    return inserted_ids
+    return location_ids


### PR DESCRIPTION
Replaced manual SQL insertions in categories, locations, and reviews fixtures with SQLAlchemy ORM model instantiation and  for cleaner and more maintainable test setup.
Also renamed date-related fixtures for reviews to use more concise names and improved pairing logic between locations and categories.