### PR TITLE
docs(readme): add live demo section with URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Map My World is a backend API for exploring and reviewing locations and categori
 
 ---
 
+## Live Demo
+
+The API is deployed and accessible here:
+
+- **Base URL:** https://map-my-world-kmsy.onrender.com
+- **Swagger UI:** https://map-my-world-kmsy.onrender.com/docs
+- **ReDoc:** https://map-my-world-kmsy.onrender.com/redoc
+
+> Note: The API uses SQLite for persistence on Render. The database resets when the service is restarted.
+
+
+---
 ## Installation
 
 1. Clone the repository:


### PR DESCRIPTION
- Added Live Demo section including Base URL, Swagger UI, and ReDoc links.
- Noted SQLite persistence limitation on Render.

This helps users and contributors quickly access and explore the running API instance.